### PR TITLE
fix crash in `calculate_joker` when `ret` is `true`

### DIFF
--- a/src/bplus/override.lua
+++ b/src/bplus/override.lua
@@ -129,6 +129,7 @@ local card_calculate_joker = Card.calculate_joker
 function Card:calculate_joker(ctx)
   local ret = card_calculate_joker(self, ctx)
   if not ret then return end
+  if ret == true then return ret end
 
   if ret.repetitions and not G.GAME.blind.disabled and G.GAME.blind.name == "bl_bplus_lazy" then
     BPlus.bl_lazy_trigger(ret.card or self)


### PR DESCRIPTION
Should fix this crash:

```
INFO - [G] 2025-05-08 02:42:27 :: ERROR :: StackTrace :: Oops! The game crashed
...Support/Balatro/Mods/balatro-plus/src/bplus/override.lua:133: attempt to index local 'ret' (a boolean value)
Stack Traceback
===============
(1) Lua local 'handler' at file 'main.lua:612'
	Local variables:
	 msg = string: "...Support/Balatro/Mods/balatro-plus/src/bplus/override.lua:133: attempt to index local 'ret' (a boolean value)"
	 (*temporary) = Lua function '?' (defined at line 31 of chunk [SMODS _ "src/logging.lua"])
	 (*temporary) = number: 2.18435e-314
	 (*temporary) = string: "Oops! The game crashed\
"
(2) LÖVE metamethod at file 'boot.lua:352'
	Local variables:
	 errhand = Lua function '?' (defined at line 598 of chunk main.lua)
	 handler = Lua function '?' (defined at line 598 of chunk main.lua)
(3) Lua upvalue 'base_calculate_joker' at file '/Users/nnmrts/Library/Application Support/Balatro/Mods/balatro-plus/src/bplus/override.lua:133'
	Local variables:
	 self = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 ctx = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
	 ret = boolean: true
	 (*temporary) = number: 6.80924e-314
	 (*temporary) = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 (*temporary) = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
	 (*temporary) = string: "attempt to index local 'ret' (a boolean value)"
(4) Lua upvalue 'calculate_joker_ref' at file 'src/powerchanges.lua:6' (from mod with id kino)
	Local variables:
	 self = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
(5) Lua local 'func' at file 'content/joker/ghost_cola.lua:61' (from mod with id paperback)
	Local variables:
	 self = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
(6) Lua upvalue 'calc_joker_func' at file 'content/joker/the_world.lua:29' (from mod with id paperback)
	Local variables:
	 ignores = nil
	 func = Lua function '?' (defined at line 45 of chunk [SMODS paperback "content/joker/the_world.lua"])
	 joker = nil
	 previous = table: 0x040fea0168  {discards_used:0, hands_played:0, hands_left:4}
(7) Lua method 'calculate_joker_reverie_ref' at file 'items/jokers.lua:1029' (from mod with id tiwmig)
	Local variables:
	 self = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
(8) Lua upvalue 'cardCalculate_jokerRef' at file 'data/main.lua:1849' (from mod with id Reverie)
	Local variables:
	 self = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
(9) Lua upvalue 'calculate_joker_ref' at file 'Items/Stickers.lua:174' (from mod with id showdown)
	Local variables:
	 self = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
(10) Lua method 'calculate_joker' at file 'lua_files/jokers/legendary/madeline.lua:62' (from mod with id CelesteCardCollection)
	Local variables:
	 self = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
	 prevent = boolean: false
	 orig_values = table: 0x040fe9ff20  {}
(11) Lua upvalue 'eval_card_ref' at file 'functions/common_events.lua:917'
	Local variables:
	 card = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
	 ret = table: 0x040fe9fbf8  {}
	 post_trig = table: 0x040fe9fc40  {}
	 areas = table: 0x040fe9fc88  {1:table: 0x0335141840, 2:table: 0x0336f2e928, 3:table: 0x03342f4308, 4:table: 0x0336e7ab18, 5:table: 0x0122f5b7f0}
	 area_set = table: 0x040fe9fd70  {table: 0x0335141840:true, table: 0x0336e7ab18:true, table: 0x03342f4308:true, table: 0x0336f2e928:true, table: 0x0122f5b7f0:true}
(12) Lua upvalue 'eval_card_ref' at file 'Betmma_Vouchers.lua:2192' (from mod with id BetmmaVouchers)
	Local variables:
	 card = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
	 (*temporary) = table: 0x040fe9fb98  {}
(13) Lua upvalue 'raw_eval_card' at file 'Betmma_Vouchers.lua:4933' (from mod with id BetmmaVouchers)
	Local variables:
	 card = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
	 (*temporary) = table: 0x040fe9fb38  {}
(14) Lua upvalue 'old_eval_card' at file 'src//util.lua:691' (from mod with id Bakery)
	Local variables:
	 card = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
(15) Lua upvalue 'eval_cardref' at file 'Grim.lua:4711' (from mod with id GRM)
	Local variables:
	 card = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
	 (*temporary) = table: 0x040fe9fad8  {}
(16) Lua upvalue 'eval_card_ref' at file 'LobotomyCorp.lua:1916' (from mod with id LobotomyCorp)
	Local variables:
	 card = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
(17) Lua upvalue 'eval_cardRef' at file 'utilities/hooks.lua:68' (from mod with id paperback)
	Local variables:
	 card = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
(18) Lua upvalue 'orig_eval_card' at file 'lua_files/decks.lua:7' (from mod with id CelesteCardCollection)
	Local variables:
	 card = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
(19) Lua global 'eval_card' at file 'src/CreationEffects.lua:233' (from mod with id RiftRaft)
	Local variables:
	 card = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
	 free_space = nil
	 (*temporary) = table: 0x040fe9fa78  {}
(20) Lua field 'calculate_card_areas' at Steamodded file 'src/utils.lua:1637'
	Local variables:
	 _type = string: "jokers"
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
	 return_table = nil
	 args = table: 0x0336884e00  {joker_area:true}
	 flags = table: 0x0336884e48  {calculated:true}
	 (for generator) = C function: builtin#6
	 (for state) = table: 0x0336884e90  {1:table: 0x0335141840, 2:table: 0x0336f2e928, 3:table: 0x03342f4308, 4:table: 0x0336e7ab18, 5:table: 0x0122f5b7f0}
	 (for control) = number: 1
	 _ = number: 1
	 area = table: 0x0335141840  {original_T:table: 0x0334b5ae78, velocity:table: 0x0334d965b8, card_w:2.0487804878049, alignment:table: 0x0334ce27e8, shadow_parrallax:table: 0x033434aff0 (more...)}
	 (for generator) = C function: builtin#6
	 (for state) = table: 0x042fd63978  {1:table: 0x042fd64268, 2:table: 0x042fe0fee0, 3:table: 0x042fe900b8, 4:table: 0x042cd0a738, 5:table: 0x03344d4330, 6:table: 0x01464b8ae8, 7:table: 0x0432a27cb8 (more...)}
	 (for control) = number: 2
	 _ = number: 2
	 _card = table: 0x042fe0fee0  {sell_cost_label:10, sort_id:405, base:table: 0x0432b2b360, original_T:table: 0x042fe5a028, config:table: 0x042fe5d9a8, alignment:table: 0x042fe15b38 (more...)}
(21) Lua field 'calculate_context' at Steamodded file 'src/utils.lua:1758'
	Local variables:
	 context = table: 0x0336884cd0  {setting_blind:true, main_eval:true, cardarea:table: 0x0335141840, blind:table: 0x032c3940f8}
	 return_table = nil
	 has_area = nil
	 flags = table: 0x0336884d50  {}
	 (*temporary) = number: 1
(22) Lua field 'func' at file 'functions/state_events.lua:799'
	Local variables:
	 blair = table: 0x042c8ce6e0  {}
	 blhash = string: "B"
(23) Lua method 'handle' at file 'engine/event.lua:132'
	Local variables:
	 self = table: 0x040f9e5fa8  {complete:false, created_on_pause:false, blockable:true, blocking:true, trigger:immediate, time:42.664356337232, delay:0, timer:TOTAL, func:function: 0x0334f738d0 (more...)}
	 _results = table: 0x042fab8b00  {time_done:false, blocking:true, completed:false, pause_skip:false}
(24) Lua upvalue 'orig_EventManager_update' at file 'engine/event.lua:218'
	Local variables:
	 self = table: 0x0122b65fb0  {queue_dt:0.016666666666667, queue_last_processed:11.9, queues:table: 0x012499ec60, queue_timer:11.904481023148}
	 dt = number: 0.00756125
	 forced = nil
	 (for generator) = C function: next
	 (for state) = table: 0x012499ec60  {galdur:table: 0x0122f8c278, base:table: 0x0124b6dcd0, unlock:table: 0x012499eca8, achievement:table: 0x0124b5da38, other:table: 0x0124b5da80 (more...)}
	 (for control) = userdata: NULL
	 k = string: "base"
	 v = table: 0x0124b6dcd0  {1:table: 0x0336927760, 2:table: 0x0122ed2040, 3:table: 0x040f9e5fa8, 4:table: 0x040f9e60e0, 5:table: 0x0125d9d0e0, 6:table: 0x042d2334b0, 7:table: 0x042becfb80 (more...)}
	 blocked = boolean: false
	 i = number: 3
	 results = table: 0x042fab8b00  {time_done:false, blocking:true, completed:false, pause_skip:false}
(25) Lua method 'update' at file 'src/RiftRaft.lua:170' (from mod with id RiftRaft)
	Local variables:
	 self = table: 0x0122b65fb0  {queue_dt:0.016666666666667, queue_last_processed:11.9, queues:table: 0x012499ec60, queue_timer:11.904481023148}
	 dt = number: 0.00756125
	 forced = nil
(26) Lua upvalue 'gameUpdateRef' at file 'game.lua:3310'
	Local variables:
	 self = table: 0x0122a960e0  {GAME:table: 0x040fbcb728, gold_bar:table: 0x0337005410, lobc_shared_modifiers:table: 0x042c067498, P_BLINDS:table: 0x032c393ac8, ACHIEVEMENTS:table: 0x0334c05150 (more...)}
	 dt = number: 0.00756125
	 http_resp = nil
(27) Lua upvalue 'upd' at Steamodded file 'src/ui.lua:86'
	Local variables:
	 self = table: 0x0122a960e0  {GAME:table: 0x040fbcb728, gold_bar:table: 0x0337005410, lobc_shared_modifiers:table: 0x042c067498, P_BLINDS:table: 0x032c393ac8, ACHIEVEMENTS:table: 0x0334c05150 (more...)}
	 dt = number: 0.00756125
(28) Lua upvalue 'game_updateref' at file 'Grim.lua:4251' (from mod with id GRM)
	Local variables:
	 self = table: 0x0122a960e0  {GAME:table: 0x040fbcb728, gold_bar:table: 0x0337005410, lobc_shared_modifiers:table: 0x042c067498, P_BLINDS:table: 0x032c393ac8, ACHIEVEMENTS:table: 0x0334c05150 (more...)}
	 dt = number: 0.00756125
(29) Lua upvalue 'game_updateref' at file 'LobotomyCorp.lua:1910' (from mod with id LobotomyCorp)
	Local variables:
	 self = table: 0x0122a960e0  {GAME:table: 0x040fbcb728, gold_bar:table: 0x0337005410, lobc_shared_modifiers:table: 0x042c067498, P_BLINDS:table: 0x032c393ac8, ACHIEVEMENTS:table: 0x0334c05150 (more...)}
	 dt = number: 0.00756125
(30) Lua upvalue 'game_updateref' at file 'other/colours.lua:1540' (from mod with id MoreFluff)
	Local variables:
	 self = table: 0x0122a960e0  {GAME:table: 0x040fbcb728, gold_bar:table: 0x0337005410, lobc_shared_modifiers:table: 0x042c067498, P_BLINDS:table: 0x032c393ac8, ACHIEVEMENTS:table: 0x0334c05150 (more...)}
	 dt = number: 0.00756125
(31) Lua upvalue 'update_ref' at file 'MoreFluff.lua:1061' (from mod with id MoreFluff)
	Local variables:
	 self = table: 0x0122a960e0  {GAME:table: 0x040fbcb728, gold_bar:table: 0x0337005410, lobc_shared_modifiers:table: 0x042c067498, P_BLINDS:table: 0x032c393ac8, ACHIEVEMENTS:table: 0x0334c05150 (more...)}
	 dt = number: 0.00756125
(32) Lua upvalue 'updateRef' at file 'hooks/game.lua:100' (from mod with id victinscollection)
	Local variables:
	 self = table: 0x0122a960e0  {GAME:table: 0x040fbcb728, gold_bar:table: 0x0337005410, lobc_shared_modifiers:table: 0x042c067498, P_BLINDS:table: 0x032c393ac8, ACHIEVEMENTS:table: 0x0334c05150 (more...)}
	 dt = number: 0.00756125
(33) Lua upvalue 'gm_u' at file 'Items/Jokers.lua:2346' (from mod with id showdown)
	Local variables:
	 self = table: 0x0122a960e0  {GAME:table: 0x040fbcb728, gold_bar:table: 0x0337005410, lobc_shared_modifiers:table: 0x042c067498, P_BLINDS:table: 0x032c393ac8, ACHIEVEMENTS:table: 0x0334c05150 (more...)}
	 dt = number: 0.00756125
(34) Lua method 'update' at file 'src/startup/game_hooks.lua:54' (from mod with id mistigris)
	Local variables:
	 self = table: 0x0122a960e0  {GAME:table: 0x040fbcb728, gold_bar:table: 0x0337005410, lobc_shared_modifiers:table: 0x042c067498, P_BLINDS:table: 0x032c393ac8, ACHIEVEMENTS:table: 0x0334c05150 (more...)}
	 dt = number: 0.00756125
(35) Lua upvalue 'love_update_ref' at file 'main.lua:1026'
	Local variables:
	 dt = number: 0.00756125
(36) Lua field 'update' at file 'main.lua:4272'
	Local variables:
	 dt = number: 0.00756125
(37) Lua function '?' at file 'main.lua:947' (best guess)
(38) global C function 'xpcall'
(39) LÖVE function at file 'boot.lua:377' (best guess)
	Local variables:
	 func = Lua function '?' (defined at line 915 of chunk main.lua)
	 inerror = boolean: true
	 deferErrhand = Lua function '(LÖVE Function)' (defined at line 348 of chunk [love "boot.lua"])
	 earlyinit = Lua function '(LÖVE Function)' (defined at line 355 of chunk [love "boot.lua"])

INFO - [G] line not found
INFO - [G] file not found: main.lua: No such file or directory
INFO - [G] file not found: main.lua: No such file or directory
INFO - [G] 2025-05-08 02:42:27 :: INFO  :: StackTrace :: Additional Context:
Balatro Version: 1.0.1o-FULL
Modded Version: 1.0.0~BETA-0506d-STEAMODDED
LÖVE Version: 11.5.0
Lovely Version: 0.7.1
Platform: OS X
Steamodded Mods:
    1: Sarcpot by SarcasticPotato [ID: sarcpot, Version: 0.1.10, Uses Lovely]
    2: FickleFox by FoxDeploy [ID: fickleFox, Priority: 1, Version: 0.0.4, Uses Lovely]
    3: Balatro+ by SomeCoder99 [ID: balatro_plus, Version: 1.0.2-a, Uses Lovely]
    4: Paperback by PaperMoon, OppositeWolf770, srockw, Nether, B [ID: paperback, Version: 0.6.4b, Uses Lovely]
    5: Jank Challenges by Lyman [ID: JankChallenges]
    6: Custom Suit Order by DigitalDetective47 [ID: SuitOrder, Priority: 1.79e+308, Version: 1.0.2]
    7: Handsome Devils by Kars, sup3p [ID: HandsomeDevils, Version: 1.0.0, Uses Lovely]
    8: Seven Deadly Decks by AstroLightz [ID: 7DeadlyDecks, Priority: -5, Version: 1.1.0]
    9: Too Many Jokers by cg [ID: toomanyjokers, Priority: 1000000, Uses Lovely]
    10: TIWMIG by Oinite [ID: tiwmig, Version: 0.1.0, Uses Lovely]
    11: Reverse Tarot + Hijinks by SkywawrdTARDIS [ID: reverse_tarot, Version: 1.5.5, Uses Lovely]
    12: Mossed by Larantula, Jetziel [ID: mossed, Priority: -20, Version: 1.0.0]
    13: Blueprint by stupxd aka stupid, Jonathan [ID: blueprint, Priority: 69, Version: 3.3, Uses Lovely]
    14: Showdown by Mistyk__ [ID: showdown, Priority: 5, Version: 1.3, Uses Lovely]
    15: Stuffz by Mini [ID: Stuffz, Version: 1.1.1]
    16: Bakery by BakersDozenBagels [ID: Bakery, Version: 2.7.3, Uses Lovely]
    17: sortatro by nnmrts [ID: sortatro, Version: 0.1.0]
    18: Reverie by DVRP [ID: Reverie, Priority: 1, Version: 1.5.3b, Uses Lovely]
    19: JankJonklersMod by Lyman [ID: JankJonklersMod]
    20: 3x Credits by AuroraAquir [ID: 3xCredits, Priority: -33, Version: 1.0.0, Uses Lovely]
    21: Card Sleeves by Larswijn [ID: CardSleeves, Priority: -10, Version: 1.7.5, Uses Lovely]
    22: rcBLib by realicraft [ID: rcblib, Priority: 120, Version: 1.1.0, Uses Lovely]
    23: Mistigris by astrapboy [ID: mistigris, Priority: 69, Version: 0.5.0-dev_25w14b, Uses Lovely]
    24: rcBalatro by realicraft [ID: rcbalatro, Priority: 126, Version: 0.2.2]
    25: Lucky Jimbos: Joker Pack by LuckySix [ID: L6_luckyjimbo, Version: 0.3~alpha-5]
    26: Betmma Voucher Pack by Betmma, nicholassam6425 [ID: BetmmaVoucherPack]
    27: Buffoonery by PinkMaggit [ID: Buffoonery, Version: 1.2.1, Uses Lovely]
    28: Celeste Card Collection by AuroraAquir, toneblock, Gappie, bein, sunsetquasar, goose! [ID: CelesteCardCollection, Priority: 10, Version: 0.37.4, Uses Lovely]
    29: DebugPlus by WilsontheWolf [ID: DebugPlus, Version: 1.5.0~dev, Uses Lovely]
    30: Cosmos by Cosmos [ID: Cosmos, Version: 0.0.3, Uses Lovely]
    31: Joker Evolution by SDM_0 [ID: joker_evolution, Priority: -1000, Version: 1.2.3c, Uses Lovely]
    32: Galdur by Eremel_ [ID: galdur, Priority: -10000, Version: 1.2, Uses Lovely]
    33: Unjankify by Blazingulag [ID: Unjank, Version: 1.0.0, Uses Lovely]
    34: Better Vouchers This Run UI by Betmma [ID: BetterVouchersThisRunUI]
    35: Betmma Vouchers by Betmma [ID: BetmmaVouchers, Priority: -1, Version: 3.0.2.2(20250504)]
    36: Balatro Goes Kino by IcyEthics [ID: kino, Version: 0.9.0b, Uses Lovely]
    37: 5 legendary challenges by Betmma [ID: legendaryChallenges]
    38: JokerDisplay by nh6574 [ID: JokerDisplay, Priority: -100000, Version: 1.8.4.1]
    39: Fusion Jokers by itayfeder, Lyman [ID: FusionJokers, Priority: -10000]
    40: Cartomancer by stupxd aka stupid [ID: cartomancer, Priority: 69, Version: 4.13-hotfix, Uses Lovely]
    41: Victin's Collection by Victin [ID: victinscollection, Uses Lovely]
    42: ExtraCredit by CampfireCollective [ID: extracredit, Priority: 1, Version: 1.3.0, Uses Lovely]
    43: Warp Zone! by Freh [ID: Wzone, Uses Lovely]
    44: Redux Arcanum by itayfeder, Lyman, Jumbo [ID: ReduxArcanum, Version: 2.0.0~PreRelease5, Uses Lovely]
    45: Prism by Blazingulag [ID: Prism, Version: 1.9.0-ALPHA, Uses Lovely]
    46: SDM_0's Stuff by SDM_0 [ID: sdm0sstuff, Version: 1.6.4o, Uses Lovely]
    47: Tsu's Jeopardy by tje.tsu [ID: TsusJeo, Version: 0.25 [TEST RELEASE]]
    48: Rift-Raft by vitellary [ID: RiftRaft, Priority: 115, Version: 1.0.0, Uses Lovely]
    49: Handy by SleepyG11 [ID: Handy, Version: 1.4.2a, Uses Lovely]
    50: SoulEverything by OppositeWolf770 [ID: SoulEverything, Version: 1.2.0]
    51: Banner by SylviBlossom [ID: banner, Version: 1.1.1, Uses Lovely]
    52: Betmma Jokers by Betmma [ID: BetmmaJokers]
    53: Snows Mods by RattlingSnow353 [ID: SnowMods, Version: 0.2.0]
    54: All in Jest by Nevernamed, survivalaiden, RattlingSnow353 [ID: allinjest, Priority: 9999, Version: 0.2.2]
    55: Familiar by RattlingSnow353, humplydinkle [ID: familiar, Priority: 1, Version: 0.2.0, Uses Lovely]
    56: UnStable by Kirbio, RamChops Games [ID: UnStable, Priority: 777, Version: 1.2b, Uses Lovely]
    57: UnStableEX by Kirbio [ID: UnStableEX, Priority: 99999, Version: 0.2.2e]
    58: Severed by frogzsj [ID: svrd, Priority: 13, Version: 0.1, Uses Lovely]
    59: Bird Jokers by Justin [ID: BirdJokers, Uses Lovely]
    60: Malverk by Eremel_ [ID: malverk, Priority: -999999, Version: 1.1.3a, Uses Lovely]
    61: Neato Jokers by Neato [ID: Neato_Jokers, Version: 1.1.6]
    62: JokerSellValue by OppositeWolf770 [ID: JokerSellValue, Priority: 100000, Version: 1.2.1]
    63: Grim by mathguy [ID: GRM, Version: 1.2.6d, Uses Lovely]
    64: KCVanilla by krackocloud [ID: kcvanilla, Version: 2.4.1, Uses Lovely]
    65: Plantain by TeamToaster [ID: plantain, Priority: 1, Version: 1.0.0, Uses Lovely]
    66: TOGA's Stuff by TheOneGoofAli [ID: TOGAPack, Priority: 2, Version: 1.4.0, Uses Lovely]
    67: Lobotomy Corporation by Mysthaps [ID: LobotomyCorp, Version: 1.2.0c, Uses Lovely]
    68: Lucky Rabbit by Fennex, Trif, HarmoniousJoker [ID: LuckyRabbit, Version: 1.1.0, Uses Lovely]
    69: Garbshit by garb [ID: GARBPACK, Version: 2.0.1, Uses Lovely]
    70: More Fluff by notmario, CHECK CREDITS IN MOD TAB [ID: MoreFluff, Version: 1.5.1, Uses Lovely]
    71: Revo's Vault by CodeRevo [ID: RevosVault, Version: 4.2.0d, Uses Lovely]
Lovely Mods:
```